### PR TITLE
Login/Logout optional when parameter

### DIFF
--- a/src/services/data-access.ts
+++ b/src/services/data-access.ts
@@ -33,12 +33,12 @@ class DataAccess implements IDataAccess {
         return this.employeeRepo.getEmployees();
     }
 
-    recordLogin(discordId: string): Promise<Date> {
-        return this.timeClockRepo.recordLogin(discordId);
+    recordLogin(discordId: string, date: Date): Promise<Date> {
+        return this.timeClockRepo.recordLogin(discordId, date);
     }
 
-    recordLogout(discordId: string): Promise<Date> {
-        return this.timeClockRepo.recordLogout(discordId);
+    recordLogout(discordId: string, date: Date): Promise<Date> {
+        return this.timeClockRepo.recordLogout(discordId, date);
     }
 
     getTimeLogged(discordIds: string[], criteria: TimeLoggedCriteria): Promise<TimeLoggedResult[]> {

--- a/src/services/discord-commands/help-command.ts
+++ b/src/services/discord-commands/help-command.ts
@@ -26,8 +26,16 @@ class HelpCommand implements DiscordCommand {
             \`!login\`
             Clocks you in at the time sent
 
+            \`!login @8:00 AM\`
+            Clocks you in at 8 AM
+
             \`!logout\`
             Clocks you out at the time sent
+
+            \`!logout @8:00 AM\`
+            Clocks you out at 8 AM
+
+            *Note: you may not login/logout more than 7 minutes in the future*
 
             \`!time\`
             Gets your hours logged for today

--- a/src/services/discord-commands/login-command.ts
+++ b/src/services/discord-commands/login-command.ts
@@ -12,6 +12,12 @@ class LoginCommand implements DiscordCommand {
     }
 
     public async execute(): Promise<void> {
+        // TODO: Glean time from args
+        // Variations noted
+        // !login @7:37 AM
+        // !login @8:03
+        // !login @8:14am
+        // !login @8:14p
         try {
             const dateObj = await this.request.dataAccess.recordLogin(this.request.message.authorId);
             this.request.message.replyCallback(`Successfully logged in at \`${dateObj.toLocaleString()}\``);

--- a/src/services/discord-commands/login-command.ts
+++ b/src/services/discord-commands/login-command.ts
@@ -1,4 +1,5 @@
 import { DiscordCommand, DiscordRequest } from "../../types";
+import { parseTimeFromArgs } from "../../util";
 
 /**
  * The login command
@@ -12,14 +13,12 @@ class LoginCommand implements DiscordCommand {
     }
 
     public async execute(): Promise<void> {
-        // TODO: Glean time from args
-        // Variations noted
-        // !login @7:37 AM
-        // !login @8:03
-        // !login @8:14am
-        // !login @8:14p
+        // Parse date from arguments
+        // If this returns null default to now
+        const date: Date = parseTimeFromArgs(this.request.args) ?? new Date();
+        
         try {
-            const dateObj = await this.request.dataAccess.recordLogin(this.request.message.authorId);
+            const dateObj = await this.request.dataAccess.recordLogin(this.request.message.authorId, date);
             this.request.message.replyCallback(`Successfully logged in at \`${dateObj.toLocaleString()}\``);
         } catch (err) {
             this.request.message.replyCallback((err as Error).message);

--- a/src/services/discord-commands/login-command.ts
+++ b/src/services/discord-commands/login-command.ts
@@ -17,6 +17,14 @@ class LoginCommand implements DiscordCommand {
         // If this returns null default to now
         const date: Date = parseTimeFromArgs(this.request.args) ?? new Date();
         
+        const buffer = new Date();
+        buffer.setMinutes(buffer.getMinutes() + 7);
+
+        if (date >= buffer) {
+            this.request.message.replyCallback(`You may not specify a time more than 7 minutes in the future, please try again.`);
+            return;
+        }
+
         try {
             const dateObj = await this.request.dataAccess.recordLogin(this.request.message.authorId, date);
             this.request.message.replyCallback(`Successfully logged in at \`${dateObj.toLocaleString()}\``);

--- a/src/services/discord-commands/logout-command.ts
+++ b/src/services/discord-commands/logout-command.ts
@@ -7,13 +7,85 @@ class LogoutCommand implements DiscordCommand {
     /**
      *
      */
-    constructor(private request: DiscordRequest) {
-
-    }
+    constructor(private request: DiscordRequest) { }
 
     public async execute(): Promise<void> {
+        const date: Date = new Date();
+        // Command expects (optional) additional argument preceded with '@'
+        const timeArg = this.request.args?.filter((item: string) => item.startsWith('@')) ?? null;
+        if (timeArg) {
+            const time = timeArg[0].slice(1).split(':');
+            let hour, minute, ampm;
+
+            if (time?.length > 0) {
+                // Probably just an hour
+
+                // Separate numbers from characters
+                const num = time[0].match(/\d+/);
+                const str = time[0].match(/([AaPp][Mm])|\b([Aa]|[Pp])/);
+
+                // Set am/pm if exists
+                if (str?.length > 0) {
+                    ampm = str[0];
+                }
+
+                // Parse hour number
+                if (num?.length > 0) {
+                    hour = parseInt(num[0], 10);
+                }
+            }
+
+            // Minute param
+            if (time?.length > 1) {
+
+                // Separate numbers from characters
+                const num = time[1].match(/\d+/);
+                const str = time[1].match(/([AaPp][Mm])|\b([Aa]|[Pp])/);
+
+                // Set am/pm if exists
+                // Overwrite if needed since am/pm usually exists after the hour
+                if (str?.length > 0) {
+                    ampm = str[0];
+                }
+                // Parse minute number
+                if (num?.length > 0) {
+                    minute = parseInt(num[0], 10);
+                }
+            }
+
+            if (!ampm) {
+                const afterTimeArgIndex = this.request.args.indexOf(timeArg[0]) + 1;
+                if (afterTimeArgIndex < this.request.args.length) {
+                    const argAfterTime = this.request.args[afterTimeArgIndex];
+
+                    const str = argAfterTime.match(/([AaPp][Mm])|\b([Aa]|[Pp])/);
+
+                    if (str?.length > 0) {
+                        ampm = str[0];
+                    }
+                }
+            }
+
+            if (hour) {
+                let dateHours = hour;
+                if (ampm) {
+                    if (ampm.match(/[Pp][Mm]|\b[Pp]/)?.length > 0) {
+                        dateHours += 12;
+                    }
+                }
+
+                date.setHours(dateHours);
+                date.setMinutes(0);
+                date.setSeconds(0);
+            }
+
+            if (minute) {
+                date.setMinutes(minute);
+            }
+        }
+
         try {
-            const dateObj = await this.request.dataAccess.recordLogout(this.request.message.authorId);
+            const dateObj = await this.request.dataAccess.recordLogout(this.request.message.authorId, date);
             this.request.message.replyCallback(`Successfully logged out at \`${dateObj.toLocaleString()}\``);
         } catch (err) {
             this.request.message.replyCallback((err as Error).message);

--- a/src/services/discord-commands/logout-command.ts
+++ b/src/services/discord-commands/logout-command.ts
@@ -22,7 +22,7 @@ class LogoutCommand implements DiscordCommand {
 
                 // Separate numbers from characters
                 const num = time[0].match(/\d+/);
-                const str = time[0].match(/([AaPp][Mm])|\b([Aa]|[Pp])/);
+                const str = time[0].match(/[AaPp][Mm]|[Aa]|[Pp]/g);
 
                 // Set am/pm if exists
                 if (str?.length > 0) {
@@ -40,7 +40,7 @@ class LogoutCommand implements DiscordCommand {
 
                 // Separate numbers from characters
                 const num = time[1].match(/\d+/);
-                const str = time[1].match(/([AaPp][Mm])|\b([Aa]|[Pp])/);
+                const str = time[1].match(/[AaPp][Mm]|[Aa]|[Pp]/g);
 
                 // Set am/pm if exists
                 // Overwrite if needed since am/pm usually exists after the hour
@@ -58,7 +58,7 @@ class LogoutCommand implements DiscordCommand {
                 if (afterTimeArgIndex < this.request.args.length) {
                     const argAfterTime = this.request.args[afterTimeArgIndex];
 
-                    const str = argAfterTime.match(/([AaPp][Mm])|\b([Aa]|[Pp])/);
+                    const str = argAfterTime.match(/[AaPp][Mm]|[Aa]|[Pp]/);
 
                     if (str?.length > 0) {
                         ampm = str[0];
@@ -69,7 +69,7 @@ class LogoutCommand implements DiscordCommand {
             if (hour) {
                 let dateHours = hour;
                 if (ampm) {
-                    if (ampm.match(/[Pp][Mm]|\b[Pp]/)?.length > 0) {
+                    if (ampm.match(/[Pp][Mm]|[Pp]/)?.length > 0) {
                         dateHours += 12;
                     }
                 }

--- a/src/services/discord-commands/logout-command.ts
+++ b/src/services/discord-commands/logout-command.ts
@@ -15,6 +15,14 @@ class LogoutCommand implements DiscordCommand {
         // If this returns null default to now
         const date: Date = parseTimeFromArgs(this.request.args) ?? new Date();
 
+        const buffer = new Date();
+        buffer.setMinutes(buffer.getMinutes() + 7);
+
+        if (date >= buffer) {
+            this.request.message.replyCallback(`You may not specify a time more than 7 minutes in the future, please try again.`);
+            return;
+        }
+
         try {
             const dateObj = await this.request.dataAccess.recordLogout(this.request.message.authorId, date);
             this.request.message.replyCallback(`Successfully logged out at \`${dateObj.toLocaleString()}\``);

--- a/src/services/discord-commands/logout-command.ts
+++ b/src/services/discord-commands/logout-command.ts
@@ -1,4 +1,5 @@
 import { DiscordCommand, DiscordRequest } from "../../types";
+import { parseTimeFromArgs } from "../../util";
 
 /**
  * The login command
@@ -10,79 +11,9 @@ class LogoutCommand implements DiscordCommand {
     constructor(private request: DiscordRequest) { }
 
     public async execute(): Promise<void> {
-        const date: Date = new Date();
-        // Command expects (optional) additional argument preceded with '@'
-        const timeArg = this.request.args?.filter((item: string) => item.startsWith('@')) ?? null;
-        if (timeArg) {
-            const time = timeArg[0].slice(1).split(':');
-            let hour, minute, ampm;
-
-            if (time?.length > 0) {
-                // Probably just an hour
-
-                // Separate numbers from characters
-                const num = time[0].match(/\d+/);
-                const str = time[0].match(/[AaPp][Mm]|[Aa]|[Pp]/g);
-
-                // Set am/pm if exists
-                if (str?.length > 0) {
-                    ampm = str[0];
-                }
-
-                // Parse hour number
-                if (num?.length > 0) {
-                    hour = parseInt(num[0], 10);
-                }
-            }
-
-            // Minute param
-            if (time?.length > 1) {
-
-                // Separate numbers from characters
-                const num = time[1].match(/\d+/);
-                const str = time[1].match(/[AaPp][Mm]|[Aa]|[Pp]/g);
-
-                // Set am/pm if exists
-                // Overwrite if needed since am/pm usually exists after the hour
-                if (str?.length > 0) {
-                    ampm = str[0];
-                }
-                // Parse minute number
-                if (num?.length > 0) {
-                    minute = parseInt(num[0], 10);
-                }
-            }
-
-            if (!ampm) {
-                const afterTimeArgIndex = this.request.args.indexOf(timeArg[0]) + 1;
-                if (afterTimeArgIndex < this.request.args.length) {
-                    const argAfterTime = this.request.args[afterTimeArgIndex];
-
-                    const str = argAfterTime.match(/[AaPp][Mm]|[Aa]|[Pp]/);
-
-                    if (str?.length > 0) {
-                        ampm = str[0];
-                    }
-                }
-            }
-
-            if (hour) {
-                let dateHours = hour;
-                if (ampm) {
-                    if (ampm.match(/[Pp][Mm]|[Pp]/)?.length > 0) {
-                        dateHours += 12;
-                    }
-                }
-
-                date.setHours(dateHours);
-                date.setMinutes(0);
-                date.setSeconds(0);
-            }
-
-            if (minute) {
-                date.setMinutes(minute);
-            }
-        }
+        // Parse date from arguments
+        // If this returns null default to now
+        const date: Date = parseTimeFromArgs(this.request.args) ?? new Date();
 
         try {
             const dateObj = await this.request.dataAccess.recordLogout(this.request.message.authorId, date);

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -16,8 +16,8 @@ export interface IEmployeeRepo {
 }
 
 export interface ITimeClockRepo {
-    recordLogin(discordId: string): Promise<Date>;
-    recordLogout(discordId: string): Promise<Date>;
+    recordLogin(discordId: string, date: Date): Promise<Date>;
+    recordLogout(discordId: string, date: Date): Promise<Date>;
     getTimeLogged(discordIds: string[], criteria: TimeLoggedCriteria): Promise<TimeLoggedResult[]>;
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,3 +25,94 @@ export function formatSeconds(seconds: number): string {
     // Hours can be a very large number so allow it to grow
     return `${hours.padStart(hours.length > 2 ? hours.length : 2, '0')}:${minute.padStart(2, '0')}:${second.padStart(2, '0')}`;
 }
+
+/**
+ * Parses a time parameter from a request argument array
+ * @param args Request argument array
+ * @returns {Date} The parsed date object
+ */
+export function parseTimeFromArgs(args: string[]): Date {
+
+    // Pull out args that match (ie: start with @)
+    const timeArg: string[] = args?.filter((item: string) => item.startsWith('@')) ?? null;
+
+    if (!timeArg) {
+        return null;
+    }
+
+    const date: Date = new Date();
+    // Cut strings that look like this 1:04 into [1, 04]
+    const time = timeArg[0].slice(1).split(':');
+    let hour, minute, ampm;
+
+    if (time?.length > 0) {
+        // Probably just an hour
+
+        // Separate numbers from characters
+        const num = time[0].match(/\d+/);
+        const str = time[0].match(/[AaPp][Mm]|[Aa]|[Pp]/g);
+
+        // Set am/pm if exists
+        if (str?.length > 0) {
+            ampm = str[0];
+        }
+
+        // Parse hour number
+        if (num?.length > 0) {
+            hour = parseInt(num[0], 10);
+        }
+    }
+
+    // Minute param
+    if (time?.length > 1) {
+
+        // Separate numbers from characters
+        const num = time[1].match(/\d+/);
+        const str = time[1].match(/[AaPp][Mm]|[Aa]|[Pp]/g);
+
+        // Set am/pm if exists
+        // Overwrite if needed since am/pm usually exists after the hour
+        if (str?.length > 0) {
+            ampm = str[0];
+        }
+        // Parse minute number
+        if (num?.length > 0) {
+            minute = parseInt(num[0], 10);
+        }
+    }
+
+    if (!ampm) {
+        const afterTimeArgIndex = args.indexOf(timeArg[0]) + 1;
+        if (afterTimeArgIndex < args.length) {
+            const argAfterTime = args[afterTimeArgIndex];
+
+            const str = argAfterTime.match(/[AaPp][Mm]|[Aa]|[Pp]/);
+
+            if (str?.length > 0) {
+                ampm = str[0];
+            }
+        }
+    }
+
+    if (hour) {
+        let dateHours = hour;
+        if (ampm) {
+            // If PM add 12 hours to hours to work with Date
+            if (ampm.match(/[Pp][Mm]|[Pp]/)?.length > 0) {
+                dateHours += 12;
+            }
+        }
+
+        // Set date HH:mm:ss
+        date.setHours(dateHours);
+        date.setMinutes(0);
+        date.setSeconds(0);
+    }
+
+    if (minute) {
+        // Set minutes from parsed time
+        date.setMinutes(minute);
+    }
+
+    return date;
+}

--- a/test/commands.spec.ts
+++ b/test/commands.spec.ts
@@ -1,8 +1,6 @@
 import 'reflect-metadata';
 import AuthorizeCommand from '../src/services/discord-commands/authorize-command';
 import ScheduleCommand from '../src/services/discord-commands/schedule-command';
-import LoginCommand from '../src/services/discord-commands/login-command';
-import LogoutCommand from '../src/services/discord-commands/logout-command';
 import { DiscordRequest, IDataAccess, MessageActionTypes, Employee, Schedule } from '../src/types';
 import { Mock, It, Times } from 'moq.ts';
 import MessageWrapper from '../src/models/message-wrapper';
@@ -279,78 +277,6 @@ describe('Commands', () => {
 
             // Assert
             mockMessage.verify(instance => instance.replyCallback(It.IsAny()), Times.Once());
-        });
-
-    });
-
-    describe('Login Command', () => {
-        let service: LoginCommand;
-        let mockDataAccess: Mock<IDataAccess>;
-        let mockMessage: Mock<MessageWrapper>;
-
-        beforeEach(() => {
-            // Mock request
-            mockMessage = new Mock<MessageWrapper>();
-            mockMessage.setup(instance => instance.authorId).returns('123');
-            mockMessage.setup(instance => instance.author).returns('Test');
-            mockMessage.setup(instance => instance.replyCallback(It.IsAny())).returns(Promise.resolve<Message>(new Mock<Message>().object()));
-
-            mockDataAccess = new Mock<IDataAccess>();
-            mockDataAccess.setup(instance => instance.recordLogin(It.IsAny())).returns(Promise.resolve());
-
-            mockRequest = new Mock<DiscordRequest>();
-            mockRequest.setup(instance => instance.message).returns(mockMessage.object());
-            mockRequest.setup(instance => instance.action).returns(MessageActionTypes.LOGIN);
-            mockRequest.setup(instance => instance.dataAccess).returns(mockDataAccess.object());
-
-            // Create service
-            service = new LoginCommand(mockRequest.object());
-        });
-
-        it('should call dataAccess once', async () => {
-            // Arrange
-
-            // Act
-            await service.execute();
-
-            // Assert
-            mockDataAccess.verify(instance => instance.recordLogin(It.IsAny()), Times.Exactly(1));
-        });
-
-    });
-
-    describe('Logout Command', () => {
-        let service: LogoutCommand;
-        let mockDataAccess: Mock<IDataAccess>;
-        let mockMessage: Mock<MessageWrapper>;
-
-        beforeEach(() => {
-            // Mock request
-            mockMessage = new Mock<MessageWrapper>();
-            mockMessage.setup(instance => instance.authorId).returns('123');
-            mockMessage.setup(instance => instance.author).returns('Test');
-            mockMessage.setup(instance => instance.replyCallback(It.IsAny())).returns(Promise.resolve<Message>(new Mock<Message>().object()));
-
-            mockDataAccess = new Mock<IDataAccess>();
-            mockDataAccess.setup(instance => instance.recordLogout(It.IsAny())).returns(Promise.resolve());
-
-            mockRequest = new Mock<DiscordRequest>();
-            mockRequest.setup(instance => instance.message).returns(mockMessage.object());
-            mockRequest.setup(instance => instance.action).returns(MessageActionTypes.LOGOUT);
-            mockRequest.setup(instance => instance.dataAccess).returns(mockDataAccess.object());
-
-            // Create service
-            service = new LogoutCommand(mockRequest.object());
-        });
-
-        it('should call dataAccess once', async () => {
-            // Arrange
-
-            // Act
-            await service.execute();
-
-            // Assert
-            mockDataAccess.verify(instance => instance.recordLogout(It.IsAny()), Times.Exactly(1));
         });
 
     });

--- a/test/data-access.spec.ts
+++ b/test/data-access.spec.ts
@@ -82,26 +82,26 @@ describe('Data Access', () => {
     describe('recordLogin()', () => {
         it('should call time clock repo', async () => {
             // Arrange
-            mockTimeClockRepo.setup(instance => instance.recordLogin(It.IsAny<string>())).returns(Promise.resolve());
+            mockTimeClockRepo.setup(instance => instance.recordLogin(It.IsAny<string>(), It.IsAny<Date>())).returns(Promise.resolve());
 
             // Act
-            await service.recordLogin('123');
+            await service.recordLogin('123', new Date());
 
             // Assert
-            mockTimeClockRepo.verify(instance => instance.recordLogin(It.IsAny<string>()), Times.Exactly(1));
+            mockTimeClockRepo.verify(instance => instance.recordLogin(It.IsAny<string>(), It.IsAny<Date>()), Times.Exactly(1));
         });
     });
 
     describe('recordLogout()', () => {
         it('should call time clock repo', async () => {
             // Arrange
-            mockTimeClockRepo.setup(instance => instance.recordLogout(It.IsAny<string>())).returns(Promise.resolve());
+            mockTimeClockRepo.setup(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>())).returns(Promise.resolve());
 
             // Act
-            await service.recordLogout('123');
+            await service.recordLogout('123', new Date());
 
             // Assert
-            mockTimeClockRepo.verify(instance => instance.recordLogout(It.IsAny<string>()), Times.Exactly(1));
+            mockTimeClockRepo.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>()), Times.Exactly(1));
         });
     });
 

--- a/test/login-logout-command.spec.ts
+++ b/test/login-logout-command.spec.ts
@@ -175,4 +175,45 @@ describe('Login/Logout time arguments', () => {
 
         });
     });
+
+    describe('Login Command', () => {
+        let mockRequest: Mock<DiscordRequest>;
+        let service: LoginCommand;
+        let mockDataAccess: Mock<IDataAccess>;
+        let mockMessage: Mock<MessageWrapper>;
+
+
+        beforeEach(() => {
+            // Mock request
+            mockMessage = new Mock<MessageWrapper>();
+            mockMessage.setup(instance => instance.authorId).returns('123');
+            mockMessage.setup(instance => instance.author).returns('Test');
+            mockMessage.setup(instance => instance.replyCallback(It.IsAny())).returns(Promise.resolve<Message>(new Mock<Message>().object()));
+
+            mockDataAccess = new Mock<IDataAccess>();
+            mockDataAccess.setup(instance => instance.recordLogin(It.IsAny(), It.IsAny<Date>())).returns(Promise.resolve());
+
+            mockRequest = new Mock<DiscordRequest>();
+            mockRequest.setup(instance => instance.message).returns(mockMessage.object());
+            mockRequest.setup(instance => instance.action).returns(MessageActionTypes.LOGIN);
+            mockRequest.setup(instance => instance.dataAccess).returns(mockDataAccess.object());
+
+            // Create service
+            service = new LoginCommand(mockRequest.object());
+        });
+
+        testCases.forEach((testCase) => {
+            it(testCase.it, async () => {
+                // Arrange
+                mockRequest.setup(instance => instance.args).returns(testCase.args);
+
+                // Act
+                await service.execute();
+
+                // Assert
+                mockDataAccess.verify(instance => instance.recordLogin(It.IsAny(), It.Is<Date>(d => d.toString().includes(testCase.expect))));
+            });
+
+        });
+    });
 });

--- a/test/login-logout-command.spec.ts
+++ b/test/login-logout-command.spec.ts
@@ -1,0 +1,178 @@
+import { Mock, It, Times } from "moq.ts";
+import { DiscordRequest, IDataAccess, MessageWrapper, MessageActionTypes } from "../src/types";
+import { Message } from "discord.js";
+import LoginCommand from "../src/services/discord-commands/login-command";
+import LogoutCommand from "../src/services/discord-commands/logout-command";
+
+describe('Login Command', () => {
+    let mockRequest: Mock<DiscordRequest>;
+    let service: LoginCommand;
+    let mockDataAccess: Mock<IDataAccess>;
+    let mockMessage: Mock<MessageWrapper>;
+
+    beforeEach(() => {
+        // Mock request
+        mockMessage = new Mock<MessageWrapper>();
+        mockMessage.setup(instance => instance.authorId).returns('123');
+        mockMessage.setup(instance => instance.author).returns('Test');
+        mockMessage.setup(instance => instance.replyCallback(It.IsAny())).returns(Promise.resolve<Message>(new Mock<Message>().object()));
+
+        mockDataAccess = new Mock<IDataAccess>();
+        mockDataAccess.setup(instance => instance.recordLogin(It.IsAny(), It.IsAny<Date>())).returns(Promise.resolve());
+
+        mockRequest = new Mock<DiscordRequest>();
+        mockRequest.setup(instance => instance.message).returns(mockMessage.object());
+        mockRequest.setup(instance => instance.action).returns(MessageActionTypes.LOGIN);
+        mockRequest.setup(instance => instance.dataAccess).returns(mockDataAccess.object());
+
+        // Create service
+        service = new LoginCommand(mockRequest.object());
+    });
+
+    it('should call dataAccess once', async () => {
+        // Arrange
+
+        // Act
+        await service.execute();
+
+        // Assert
+        mockDataAccess.verify(instance => instance.recordLogin(It.IsAny(), It.IsAny<Date>()), Times.Exactly(1));
+    });
+
+    it('should reply', async () => {
+        // Arrange
+
+        // Act
+        await service.execute();
+
+        // Assert
+        mockMessage.verify(instance => instance.replyCallback(It.IsAny<string>()), Times.Once());
+    });
+
+});
+
+describe('Logout Command', () => {
+    let mockRequest: Mock<DiscordRequest>;
+    let service: LogoutCommand;
+    let mockDataAccess: Mock<IDataAccess>;
+    let mockMessage: Mock<MessageWrapper>;
+
+    beforeEach(() => {
+        // Mock request
+        mockMessage = new Mock<MessageWrapper>();
+        mockMessage.setup(instance => instance.authorId).returns('123');
+        mockMessage.setup(instance => instance.author).returns('Test');
+        mockMessage.setup(instance => instance.replyCallback(It.IsAny())).returns(Promise.resolve<Message>(new Mock<Message>().object()));
+
+        mockDataAccess = new Mock<IDataAccess>();
+        mockDataAccess.setup(instance => instance.recordLogout(It.IsAny(), It.IsAny<Date>())).returns(Promise.resolve());
+
+        mockRequest = new Mock<DiscordRequest>();
+        mockRequest.setup(instance => instance.message).returns(mockMessage.object());
+        mockRequest.setup(instance => instance.action).returns(MessageActionTypes.LOGOUT);
+        mockRequest.setup(instance => instance.dataAccess).returns(mockDataAccess.object());
+
+        // Create service
+        service = new LogoutCommand(mockRequest.object());
+    });
+
+    it('should call dataAccess once', async () => {
+        // Arrange
+
+        // Act
+        await service.execute();
+
+        // Assert
+        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny(), It.IsAny<Date>()), Times.Exactly(1));
+    });
+
+    it('should reply', async () => {
+        // Arrange
+
+        // Act
+        await service.execute();
+
+        // Assert
+        mockMessage.verify(instance => instance.replyCallback(It.IsAny<string>()), Times.Once());
+    });
+
+});
+
+
+describe('Login/Logout time arguments', () => {
+
+    // Test cases for parsing time between commands
+    const testCases = [
+        {
+            it: 'should parse @7:37 AM',
+            args: ['@7:37', 'AM'],
+            expect: '7:37'
+        },
+        {
+            it: 'should parse @8:03',
+            args: ['@8:03'],
+            expect: '8:03'
+        },
+        {
+            it: 'should parse @8:14am',
+            args: ['@8:14am'],
+            expect: '8:14'
+        },
+        {
+            it: 'should parse @8:14p',
+            args: ['@8:14p'],
+            expect: '8:14'
+        },
+        {
+            it: 'should parse @8p',
+            args: ['@8p'],
+            expect: '8:00'
+        },
+        {
+            it: 'should parse @4 PM',
+            args: ['@4', 'PM'],
+            expect: '4:00'
+        }
+    ];
+
+    describe('Logout Command', () => {
+        let mockRequest: Mock<DiscordRequest>;
+        let service: LogoutCommand;
+        let mockDataAccess: Mock<IDataAccess>;
+        let mockMessage: Mock<MessageWrapper>;
+
+
+        beforeEach(() => {
+            // Mock request
+            mockMessage = new Mock<MessageWrapper>();
+            mockMessage.setup(instance => instance.authorId).returns('123');
+            mockMessage.setup(instance => instance.author).returns('Test');
+            mockMessage.setup(instance => instance.replyCallback(It.IsAny())).returns(Promise.resolve<Message>(new Mock<Message>().object()));
+
+            mockDataAccess = new Mock<IDataAccess>();
+            mockDataAccess.setup(instance => instance.recordLogout(It.IsAny(), It.IsAny<Date>())).returns(Promise.resolve());
+
+            mockRequest = new Mock<DiscordRequest>();
+            mockRequest.setup(instance => instance.message).returns(mockMessage.object());
+            mockRequest.setup(instance => instance.action).returns(MessageActionTypes.LOGOUT);
+            mockRequest.setup(instance => instance.dataAccess).returns(mockDataAccess.object());
+
+            // Create service
+            service = new LogoutCommand(mockRequest.object());
+        });
+
+        testCases.forEach((testCase) => {
+            it(testCase.it, async () => {
+                // Arrange
+                mockRequest.setup(instance => instance.args).returns(testCase.args);
+
+                // Act
+                await service.execute();
+
+                // Assert
+                mockDataAccess.verify(instance => instance.recordLogout(It.IsAny(), It.Is<Date>(d => d.toString().includes(testCase.expect))));
+            });
+
+        });
+    });
+});

--- a/test/login-logout-command.spec.ts
+++ b/test/login-logout-command.spec.ts
@@ -121,17 +121,17 @@ describe('Login/Logout time arguments', () => {
         {
             it: 'should parse @8:14p',
             args: ['@8:14p'],
-            expect: '8:14'
+            expect: '20:14'
         },
         {
             it: 'should parse @8p',
             args: ['@8p'],
-            expect: '8:00'
+            expect: '20:00'
         },
         {
             it: 'should parse @4 PM',
             args: ['@4', 'PM'],
-            expect: '4:00'
+            expect: '16:00'
         }
     ];
 

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -1,0 +1,57 @@
+import { assert } from "chai";
+import { parseTimeFromArgs } from "../src/util";
+
+describe('Util', () => {
+
+    describe('parseTimeFromArgs()', () => {
+
+        // Test cases for parsing time between commands
+    const testCases = [
+        {
+            it: 'should parse @7:37 AM',
+            args: ['@7:37', 'AM'],
+            expect: '7:37'
+        },
+        {
+            it: 'should parse @8:03',
+            args: ['@8:03'],
+            expect: '8:03'
+        },
+        {
+            it: 'should parse @8:14am',
+            args: ['@8:14am'],
+            expect: '8:14'
+        },
+        {
+            it: 'should parse @8:14p',
+            args: ['@8:14p'],
+            expect: '20:14'
+        },
+        {
+            it: 'should parse @8p',
+            args: ['@8p'],
+            expect: '20:00'
+        },
+        {
+            it: 'should parse @4 PM',
+            args: ['@4', 'PM'],
+            expect: '16:00'
+        }
+    ];
+
+    testCases.forEach((testCase) => {
+        it(testCase.it, async () => {
+            // Arrange
+
+            // Act
+            const result = parseTimeFromArgs(testCase.args);
+
+            // Assert
+            assert(result.toString().includes(testCase.expect));
+        });
+
+    });
+
+    });
+
+});


### PR DESCRIPTION
Closes #16 

The login and logout commands now handle an optional 'when' parameter.

For example
`!login @8 am`

This will log you in at 8 am instead of when the message was sent.

The command will not allow time parameters in the future.  For example if it was 8 am and you attempt to login with `@9am`, the system will not log you in and you will have to try again.

The help command has been updated to reflect the new parameter.

Variations tested:
`@7:37 AM`
`@8:03` <-- Assumes 'AM'
`@8:14am`
`@8:14p`
`@8p`
`@4 PM`