### PR TITLE
Fix login and logout constraints

### DIFF
--- a/src/services/data-access.ts
+++ b/src/services/data-access.ts
@@ -51,6 +51,10 @@ class DataAccess implements IDataAccess {
         return this.timeClockRepo.getPunches(discordIds, criteria);
     }
 
+    lastClock(discordId: string): Promise<TimeClockRecord> {
+        return this.timeClockRepo.lastClock(discordId)
+    }
+
     getSchedules(...employees: Employee[]): Promise<Schedule[]> {
         return this.scheduleRepo.getSchedules(...employees);
     }

--- a/src/services/data-access.ts
+++ b/src/services/data-access.ts
@@ -39,8 +39,8 @@ class DataAccess implements IDataAccess {
         return this.timeClockRepo.recordLogin(discordId, date);
     }
 
-    recordLogout(discordId: string, date: Date): Promise<Date> {
-        return this.timeClockRepo.recordLogout(discordId, date);
+    recordLogout(discordId: string, date: Date, loginDate: Date): Promise<Date> {
+        return this.timeClockRepo.recordLogout(discordId, date, loginDate);
     }
 
     getTimeLogged(discordIds: string[], criteria: TimeLoggedCriteria): Promise<TimeLoggedResult[]> {

--- a/src/services/discord-commands/login-command.ts
+++ b/src/services/discord-commands/login-command.ts
@@ -1,5 +1,6 @@
-import { DiscordCommand, DiscordRequest } from "../../types";
+import { DiscordCommand, DiscordRequest, TimeClockRecord } from "../../types";
 import { parseTimeFromArgs } from "../../util";
+import { isNullOrUndefined } from "util";
 
 /**
  * The login command
@@ -16,20 +17,46 @@ class LoginCommand implements DiscordCommand {
         // Parse date from arguments
         // If this returns null default to now
         const date: Date = parseTimeFromArgs(this.request.args) ?? new Date();
-        
+
         const buffer = new Date();
         buffer.setMinutes(buffer.getMinutes() + 7);
 
         if (date >= buffer) {
-            this.request.message.replyCallback(`You may not specify a time more than 7 minutes in the future, please try again.`);
+            await this.request.message.replyCallback(`You may not specify a time more than 7 minutes in the future, please try again.`);
+            return;
+        }
+
+        let lastClock: TimeClockRecord;
+        try {
+            lastClock = await this.request.dataAccess.lastClock(this.request.message.authorId);
+        } catch (err) {
+            console.error(err);
+            await this.request.message.replyCallback('There was an issue logging in, please try again.\r\nIf this issue persists please let an administrator know.');
+            return;
+        }
+
+        // Make sure a login is allowed
+        // Last clock should have a logout date time
+        if (lastClock && isNullOrUndefined(lastClock.LogoutDateTimeUtc)) {
+            const previousClockInMessage = `Previous clock in detected at ${lastClock.LoginDateTimeUtc.toLocaleString()}.`;
+            console.warn(`User [${this.request.message.authorId}], ${previousClockInMessage}`);
+            await this.request.message.replyCallback(`There was an issue logging in.  ${previousClockInMessage}`);
+            return;
+        }
+
+        // The current time argument should not occur before the last clock
+        if (lastClock && (lastClock.LogoutDateTimeUtc > date)) {
+            const previousClockOutMessage = `Previous clock out detected at ${lastClock.LoginDateTimeUtc.toLocaleString()}, you may not login before your last log out.`;
+            console.warn(`User [${this.request.message.authorId}], ${previousClockOutMessage}`);
+            await this.request.message.replyCallback(`There was an issue logging in.  ${previousClockOutMessage}`);
             return;
         }
 
         try {
             const dateObj = await this.request.dataAccess.recordLogin(this.request.message.authorId, date);
-            this.request.message.replyCallback(`Successfully logged in at \`${dateObj.toLocaleString()}\``);
+            await this.request.message.replyCallback(`Successfully logged in at \`${dateObj.toLocaleString()}\``);
         } catch (err) {
-            this.request.message.replyCallback((err as Error).message);
+            await this.request.message.replyCallback((err as Error).message);
         }
     }
 }

--- a/src/services/discord-commands/login-command.ts
+++ b/src/services/discord-commands/login-command.ts
@@ -46,7 +46,7 @@ class LoginCommand implements DiscordCommand {
 
         // The current time argument should not occur before the last clock
         if (lastClock && (lastClock.LogoutDateTimeUtc > date)) {
-            const previousClockOutMessage = `Previous clock out detected at ${lastClock.LoginDateTimeUtc.toLocaleString()}, you may not login before your last log out.`;
+            const previousClockOutMessage = `Previous clock out detected at ${lastClock.LogoutDateTimeUtc.toLocaleString()}, you may not login before your last log out.`;
             console.warn(`User [${this.request.message.authorId}], ${previousClockOutMessage}`);
             await this.request.message.replyCallback(`There was an issue logging in.  ${previousClockOutMessage}`);
             return;

--- a/src/services/discord-commands/logout-command.ts
+++ b/src/services/discord-commands/logout-command.ts
@@ -50,7 +50,7 @@ class LogoutCommand implements DiscordCommand {
         }
 
         try {
-            const dateObj = await this.request.dataAccess.recordLogout(this.request.message.authorId, date);
+            const dateObj = await this.request.dataAccess.recordLogout(this.request.message.authorId, date, lastClock.LoginDateTimeUtc);
             this.request.message.replyCallback(`Successfully logged out at \`${dateObj.toLocaleString()}\``);
         } catch (err) {
             this.request.message.replyCallback((err as Error).message);

--- a/src/services/time-clock-repo.ts
+++ b/src/services/time-clock-repo.ts
@@ -16,7 +16,7 @@ class TimeClockRepo implements ITimeClockRepo {
 
     }
 
-    private async lastClock(discordId: string): Promise<TimeClockRecord> {
+    public async lastClock(discordId: string): Promise<TimeClockRecord> {
         return await DatabaseUtil.executeResultsAsync<TimeClockRecord>(this.appConfig.sqlite.databasePath, (db: Database) => new Promise((res, rej) => {
             const sql = 'SELECT * FROM TimeClock WHERE DiscordId = ? AND LogoutDateTimeUtc IS NULL ORDER BY LoginDateTimeUtc DESC, LogoutDateTimeUtc DESC LIMIT 1;';
 

--- a/src/services/time-clock-repo.ts
+++ b/src/services/time-clock-repo.ts
@@ -3,7 +3,6 @@ import AppConfig from '../models/app-config';
 import { ITimeClockRepo, TimeClockRecord, TimeLoggedCriteria, TimeLoggedResult } from '../types';
 import DatabaseUtil from './db-util';
 import { Database } from 'sqlite3';
-import { isNullOrUndefined } from 'util';
 import { getDatesFromCriteria } from '../util';
 
 @injectable()
@@ -72,12 +71,6 @@ class TimeClockRepo implements ITimeClockRepo {
     }
 
     async recordLogin(discordId: string, date: Date): Promise<Date> {
-        const lastClock = await this.lastClock(discordId);
-
-        if (lastClock && isNullOrUndefined(lastClock.LogoutDateTimeUtc)) {
-            throw new Error(`There was an issue logging in.  Previous clock in detected at ${lastClock.LoginDateTimeUtc.toLocaleString()}.`);
-        }
-
         await DatabaseUtil.executeNonQueryDb(this.appConfig.sqlite.databasePath, (db: Database) => new Promise((res, rej) => {
             const sql = `INSERT INTO TimeClock (DiscordId, LoginDateTimeUtc) VALUES (?, ?);`;
 

--- a/src/services/time-clock-repo.ts
+++ b/src/services/time-clock-repo.ts
@@ -88,12 +88,6 @@ class TimeClockRepo implements ITimeClockRepo {
     }
 
     async recordLogout(discordId: string, date: Date): Promise<Date> {
-        const lastClock = await this.lastClock(discordId);
-
-        if (!lastClock || lastClock.LogoutDateTimeUtc) {
-            throw new Error(`There was an issue logging out.  Previous clock out detected at ${lastClock?.LogoutDateTimeUtc?.toLocaleString() ?? 'never'}.`);
-        }
-
         await DatabaseUtil.executeNonQueryDb(this.appConfig.sqlite.databasePath, (db: Database) => new Promise((res, rej) => {
             const sql = `UPDATE TimeClock SET LogoutDateTimeUtc = ? WHERE DiscordId = ? AND LoginDateTimeUtc = ?;`;
 

--- a/src/services/time-clock-repo.ts
+++ b/src/services/time-clock-repo.ts
@@ -17,7 +17,7 @@ class TimeClockRepo implements ITimeClockRepo {
 
     public async lastClock(discordId: string): Promise<TimeClockRecord> {
         return await DatabaseUtil.executeResultsAsync<TimeClockRecord>(this.appConfig.sqlite.databasePath, (db: Database) => new Promise((res, rej) => {
-            const sql = 'SELECT * FROM TimeClock WHERE DiscordId = ? AND LogoutDateTimeUtc IS NULL ORDER BY LoginDateTimeUtc DESC, LogoutDateTimeUtc DESC LIMIT 1;';
+            const sql = 'SELECT * FROM TimeClock WHERE DiscordId = ? ORDER BY LoginDateTimeUtc DESC, LogoutDateTimeUtc DESC LIMIT 1;';
 
             db.get(sql, [discordId], (err: Error, row: TimeClockRecord) => {
                 if (err) {
@@ -87,11 +87,11 @@ class TimeClockRepo implements ITimeClockRepo {
         return date;
     }
 
-    async recordLogout(discordId: string, date: Date): Promise<Date> {
+    async recordLogout(discordId: string, date: Date, loginDate: Date): Promise<Date> {
         await DatabaseUtil.executeNonQueryDb(this.appConfig.sqlite.databasePath, (db: Database) => new Promise((res, rej) => {
             const sql = `UPDATE TimeClock SET LogoutDateTimeUtc = ? WHERE DiscordId = ? AND LoginDateTimeUtc = ?;`;
 
-            db.run(sql, [date.toISOString(), discordId, lastClock.LoginDateTimeUtc.toISOString()], (err) => {
+            db.run(sql, [date.toISOString(), discordId, loginDate.toISOString()], (err) => {
                 if (err) {
                     rej(err);
                     return;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -22,7 +22,7 @@ export interface IEmployeeRepo {
 
 export interface ITimeClockRepo {
     recordLogin(discordId: string, date: Date): Promise<Date>;
-    recordLogout(discordId: string, date: Date): Promise<Date>;
+    recordLogout(discordId: string, date: Date, loginDate: Date): Promise<Date>;
     getTimeLogged(discordIds: string[], criteria: TimeLoggedCriteria): Promise<TimeLoggedResult[]>;
     getPunches(discordIds: string[], criteria: TimeLoggedCriteria): Promise<TimeClockRecord[]>;
     lastClock(discordId: string): Promise<TimeClockRecord>;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -25,6 +25,7 @@ export interface ITimeClockRepo {
     recordLogout(discordId: string, date: Date): Promise<Date>;
     getTimeLogged(discordIds: string[], criteria: TimeLoggedCriteria): Promise<TimeLoggedResult[]>;
     getPunches(discordIds: string[], criteria: TimeLoggedCriteria): Promise<TimeClockRecord[]>;
+    lastClock(discordId: string): Promise<TimeClockRecord>;
 }
 
 export interface IScheduleRepo {

--- a/test/data-access.spec.ts
+++ b/test/data-access.spec.ts
@@ -95,13 +95,13 @@ describe('Data Access', () => {
     describe('recordLogout()', () => {
         it('should call time clock repo', async () => {
             // Arrange
-            mockTimeClockRepo.setup(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>())).returns(Promise.resolve());
+            mockTimeClockRepo.setup(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>(), It.IsAny<Date>())).returns(Promise.resolve());
 
             // Act
-            await service.recordLogout('123', new Date());
+            await service.recordLogout('123', new Date(), new Date());
 
             // Assert
-            mockTimeClockRepo.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>()), Times.Exactly(1));
+            mockTimeClockRepo.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>(), It.IsAny<Date>()), Times.Exactly(1));
         });
     });
 

--- a/test/login-logout-command.spec.ts
+++ b/test/login-logout-command.spec.ts
@@ -189,7 +189,7 @@ describe('Logout Command', () => {
                 });
             });
         mockDataAccess
-            .setup(instance => instance.recordLogout(It.IsAny(), It.IsAny<Date>()))
+            .setup(instance => instance.recordLogout(It.IsAny(), It.IsAny<Date>(), It.IsAny<Date>()))
             .returns(Promise.resolve());
 
         mockRequest = new Mock<DiscordRequest>();
@@ -214,7 +214,7 @@ describe('Logout Command', () => {
         await service.execute();
 
         // Assert
-        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny(), It.IsAny<Date>()), Times.Exactly(1));
+        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny(), It.IsAny<Date>(), It.IsAny<Date>()), Times.Exactly(1));
     });
 
     it('should reply', async () => {
@@ -237,7 +237,7 @@ describe('Logout Command', () => {
         await service.execute();
 
         // Assert
-        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>()), Times.Never());
+        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>(), It.IsAny<Date>()), Times.Never());
         mockMessage.verify(instance => instance.replyCallback(It.Is<string>(s => s.includes('please try again'))), Times.Once());
     });
 
@@ -251,7 +251,7 @@ describe('Logout Command', () => {
         await service.execute();
 
         // Assert
-        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>()), Times.Once());
+        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>(), It.IsAny<Date>()), Times.Once());
     });
 
     it('should reply error when last clock fails', async () => {
@@ -265,7 +265,7 @@ describe('Logout Command', () => {
 
         // Assert
         mockMessage.verify(instance => instance.replyCallback(It.Is<string>(s => s.includes('please try again'))), Times.Once());
-        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>()), Times.Never());
+        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>(), It.IsAny<Date>()), Times.Never());
     });
 
     it('should reply previous clock in when previous logout detected', async () => {
@@ -289,7 +289,7 @@ describe('Logout Command', () => {
 
         // Assert
         mockMessage.verify(instance => instance.replyCallback(It.Is<string>(s => s.includes('Previous clock out detected'))), Times.Once());
-        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>()), Times.Never());
+        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>(), It.IsAny<Date>()), Times.Never());
     });
 
     it('should reply error when logout before last login', async () => {
@@ -303,7 +303,7 @@ describe('Logout Command', () => {
 
         // Assert
         mockMessage.verify(instance => instance.replyCallback(It.Is<string>(s => s.includes('There was an issue'))), Times.Once());
-        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>()), Times.Never());
+        mockDataAccess.verify(instance => instance.recordLogout(It.IsAny<string>(), It.IsAny<Date>(), It.IsAny<Date>()), Times.Never());
     });
 
 });

--- a/test/login-logout-command.spec.ts
+++ b/test/login-logout-command.spec.ts
@@ -1,5 +1,5 @@
 import { Mock, It, Times } from "moq.ts";
-import { DiscordRequest, IDataAccess, MessageWrapper, MessageActionTypes } from "../src/types";
+import { DiscordRequest, IDataAccess, MessageWrapper, MessageActionTypes, TimeClockRecord } from "../src/types";
 import { Message } from "discord.js";
 import LoginCommand from "../src/services/discord-commands/login-command";
 import LogoutCommand from "../src/services/discord-commands/logout-command";
@@ -13,17 +13,45 @@ describe('Login Command', () => {
     beforeEach(() => {
         // Mock request
         mockMessage = new Mock<MessageWrapper>();
-        mockMessage.setup(instance => instance.authorId).returns('123');
-        mockMessage.setup(instance => instance.author).returns('Test');
-        mockMessage.setup(instance => instance.replyCallback(It.IsAny())).returns(Promise.resolve<Message>(new Mock<Message>().object()));
+        mockMessage
+            .setup(instance => instance.authorId)
+            .returns('123');
+        mockMessage
+            .setup(instance => instance.author)
+            .returns('Test');
+        mockMessage
+            .setup(instance => instance.replyCallback(It.IsAny()))
+            .returns(Promise.resolve<Message>(new Mock<Message>().object()));
 
         mockDataAccess = new Mock<IDataAccess>();
-        mockDataAccess.setup(instance => instance.recordLogin(It.IsAny(), It.IsAny<Date>())).returns(Promise.resolve());
+        mockDataAccess
+            .setup(instance => instance.lastClock(It.IsAny<string>()))
+            .callback(({ args: [discordId] }) => {
+                const start = new Date();
+                const end = new Date();
+                // Valid login occurs when last clock is fully filled out
+                start.setMinutes(start.getMinutes() - 60);
+                end.setMinutes(end.getMinutes() - 30);
+                return Promise.resolve<TimeClockRecord>({
+                    DiscordId: discordId,
+                    LoginDateTimeUtc: start,
+                    LogoutDateTimeUtc: end
+                });
+            });
+        mockDataAccess
+            .setup(instance => instance.recordLogin(It.IsAny(), It.IsAny<Date>()))
+            .returns(Promise.resolve());
 
         mockRequest = new Mock<DiscordRequest>();
-        mockRequest.setup(instance => instance.message).returns(mockMessage.object());
-        mockRequest.setup(instance => instance.action).returns(MessageActionTypes.LOGIN);
-        mockRequest.setup(instance => instance.dataAccess).returns(mockDataAccess.object());
+        mockRequest
+            .setup(instance => instance.message)
+            .returns(mockMessage.object());
+        mockRequest
+            .setup(instance => instance.action)
+            .returns(MessageActionTypes.LOGIN);
+        mockRequest
+            .setup(instance => instance.dataAccess)
+            .returns(mockDataAccess.object());
 
         // Create service
         service = new LoginCommand(mockRequest.object());
@@ -74,6 +102,56 @@ describe('Login Command', () => {
 
         // Assert
         mockDataAccess.verify(instance => instance.recordLogin(It.IsAny<string>(), It.IsAny<Date>()), Times.Once());
+    });
+
+    it('should reply error when last clock fails', async () => {
+        // Arrange
+        mockDataAccess
+            .setup(instance => instance.lastClock(It.IsAny<string>()))
+            .returns(Promise.reject(new Error('Some test error')));
+
+        // Act
+        await service.execute();
+
+        // Assert
+        mockMessage.verify(instance => instance.replyCallback(It.Is<string>(s => s.includes('please try again'))), Times.Once());
+        mockDataAccess.verify(instance => instance.recordLogin(It.IsAny<string>(), It.IsAny<Date>()), Times.Never());
+    });
+
+    it('should reply previous clock in when previous login detected', async () => {
+        // Arrange
+        mockDataAccess
+            .setup(instance => instance.lastClock(It.IsAny<string>()))
+            .callback(({ args: [discordId] }) => {
+                const start = new Date();
+                start.setMinutes(start.getMinutes() - 60);
+                return Promise.resolve<TimeClockRecord>({
+                    DiscordId: discordId,
+                    LoginDateTimeUtc: start,
+                    LogoutDateTimeUtc: undefined
+                });
+            });
+
+        // Act
+        await service.execute();
+
+        // Assert
+        mockMessage.verify(instance => instance.replyCallback(It.Is<string>(s => s.includes('Previous clock in detected'))), Times.Once());
+        mockDataAccess.verify(instance => instance.recordLogin(It.IsAny<string>(), It.IsAny<Date>()), Times.Never());
+});
+
+    it('should reply error when login before last logout', async () => {
+        // Arrange
+        const date = new Date();
+        date.setMinutes(date.getMinutes() - 35);
+        mockRequest.setup(instance => instance.args).returns([`@${date.getHours()}`]);
+
+        // Act
+        await service.execute();
+
+        // Assert
+        mockMessage.verify(instance => instance.replyCallback(It.Is<string>(s => s.includes('There was an issue'))), Times.Once());
+        mockDataAccess.verify(instance => instance.recordLogin(It.IsAny<string>(), It.IsAny<Date>()), Times.Never());
     });
 
 });

--- a/test/login-logout-command.spec.ts
+++ b/test/login-logout-command.spec.ts
@@ -95,7 +95,7 @@ describe('Login Command', () => {
         // Arrange
         const date = new Date();
         date.setMinutes(date.getMinutes() + 6);
-        mockRequest.setup(instance => instance.args).returns([`@${date.getHours()}`]);
+        mockRequest.setup(instance => instance.args).returns([`@${date.getHours()}:${date.getMinutes()}`]);
 
         // Act
         await service.execute();
@@ -245,7 +245,7 @@ describe('Logout Command', () => {
         // Arrange
         const date = new Date();
         date.setMinutes(date.getMinutes() + 6);
-        mockRequest.setup(instance => instance.args).returns([`@${date.getHours()}`]);
+        mockRequest.setup(instance => instance.args).returns([`@${date.getHours()}:${date.getMinutes()}`]);
 
         // Act
         await service.execute();


### PR DESCRIPTION
Fixes #21

Logins can no longer occur before previous logouts

Logouts can no longer occur before previous logins

Moved validation into the command so data service doesn't work too hard and to improve testing.